### PR TITLE
Remove the inserted tag when stopping x-ray

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The project makes use of the styles from ghost.css, which is what enables you to
 
 Grab the code below (```x-ray.js```):
 ```javascript
-javascript: ( function () { var style = "<style>*{background:#000!important;color:#0f0!important;outline:solid #f00 1px!important;}</style>"; var elements = document.body.getElementsByTagName("*"); var items = []; for (var i = 0; i < elements.length; i++) { if (elements[i].innerHTML.indexOf("background:#000!important;color:#0f0!important;outline:solid #f00 1px!important;") != -1) { items.push(elements[i]); } } if (items.length > 0) { for (var i = 0; i < items.length; i++) { items[i].innerHTML = ""; } } else { document.body.innerHTML += style; } } )();
+javascript: ( function () { var style = "<style>*{background:#000!important;color:#0f0!important;outline:solid #f00 1px!important;}</style>"; var elements = document.body.getElementsByTagName("*"); var items = []; for (var i = 0; i < elements.length; i++) { if (elements[i].innerHTML.indexOf("background:#000!important;color:#0f0!important;outline:solid #f00 1px!important;") != -1) { items.push(elements[i]); } } if (items.length > 0) { for (var i = 0; i < items.length; i++) { document.body.removeChild(items[i]); } } else { document.body.innerHTML += style; } } )();
 ``` 
 
 Now drag it onto your bookmarks, or create a bookmark and paste the code in the URL/location field. Enjoy!

--- a/x-ray-debug.js
+++ b/x-ray-debug.js
@@ -12,10 +12,9 @@ javascript: (
             console.log("Stopping x-ray");
             console.log("Num items in items: " + items.length);
             for (var i = 0; i < items.length; i++) {
+                console.log("Removing:");
                 console.log(items[i]);
-                console.log("Before: " + items[i].innerHTML);
-                items[i].innerHTML = "";
-                console.log("After: " + items[i].innerHTML);
+                document.body.removeChild(items[i]);
             }
         } else {
             console.log("Starting x-ray");

--- a/x-ray.js
+++ b/x-ray.js
@@ -10,7 +10,7 @@ javascript: (
 
         if (items.length > 0) {
             for (var i = 0; i < items.length; i++) {
-                items[i].innerHTML = "";
+                document.body.removeChild(items[i]);
             }
         } else {
             document.body.innerHTML += "<style>*{background:#000!important;color:#0f0!important;outline:solid #f00 1px!important;}</style>";


### PR DESCRIPTION
Hi! 👋 This should resolve issue #1.

I'm using `removeChild()` to maintain IE 9+ support, but `items[i].remove()` is an option in the future.