### PR TITLE
Rewrite the script to make it more maintainable and robust

### DIFF
--- a/x-ray.js
+++ b/x-ray.js
@@ -1,19 +1,12 @@
 javascript: (
-    function () {
-        var elements = document.body.getElementsByTagName("*");
-        var items = [];
-        for (var i = 0; i < elements.length; i++) {
-            if (elements[i].innerHTML.indexOf("background:#000!important;color:#0f0!important;outline:solid #f00 1px!important;") != -1) {
-                items.push(elements[i]);
-            }
-        }
-
-        if (items.length > 0) {
-            for (var i = 0; i < items.length; i++) {
-                document.body.removeChild(items[i]);
-            }
-        } else {
-            document.body.innerHTML += "<style>*{background:#000!important;color:#0f0!important;outline:solid #f00 1px!important;}</style>";
-        }
+  function () {
+    const xray = document.createElement('style');
+    xray.innerHTML = "*{background:#000!important;color:#0f0!important;outline:solid #f00 1px!important;}";
+    const xraysInPage = [...document.body.getElementsByTagName("style")].filter(style => style.innerHTML === xray.innerHTML);
+    if(xraysInPage.length > 0) {
+      xraysInPage.forEach(style => document.body.removeChild(style));
+    } else {
+      document.body.appendChild(xray)
     }
-)();    
+  }
+)();


### PR DESCRIPTION
Selecting all elements on the page using `document.getElementsByTagName('*')` is unnecessary: we're only interested in `style` tags. There was also some code duplication, having the style defined in multiple places rather than a single one.

With this rewrite, I create a style element and give it the necessary css, but only in one place, so if you want to change the style of your xray you only need to do it once and don't have to worry about typos or copy paste errors.

Then I select all `style` elements in the page and filter them to only keep those with the same inner HTML as my new style element, which will only happen if it's already been inserted into the page. If there are any, I remove them, if there are none, I append one to the document's body.

This approach has the advantage that it won't match the ghost css if it's in the page unless it's actually in a real style tag, meaning it won't remove anything it's not supposed to (in its current state, your script completely messes up the xray blog entry [on your site](https://benscabbia.co.uk/projects/x-ray)), so this also "fixes" #3 for your site. As a side note, the script won't work on github (and probably other sites) because of the CSP that disallows you to run any javascript from a bookmark on their pages, but there's nothing that can be done about that.

Aside from that, I think using the `filter()` and `forEach()` methods on arrays is much more elegant and readable (it conveys intent) than for loops with counters, but that's really a matter of preference.

Looking forward to hearing what you think,
Samuel Degueldre